### PR TITLE
feat(developer): add progress comments to linked GitHub issues

### DIFF
--- a/docs/Services/StoryProgressCommentService.md
+++ b/docs/Services/StoryProgressCommentService.md
@@ -1,0 +1,197 @@
+# StoryProgressCommentService
+
+## Overview
+
+`StoryProgressCommentService` posts real-time progress comments to the GitHub issue linked to a story during its execution. This keeps stakeholders informed of where Aura is in the implementation lifecycle without them having to poll the Aura UI.
+
+The service is registered as `IStoryProgressCommentService` and is injected into `StoryService`, which calls it at the following lifecycle points:
+
+| Lifecycle point | Comment posted |
+|---|---|
+| Analysis complete | Issue analysis is done; planning is next |
+| Planning complete | Plan created with step count; execution is starting |
+| Wave complete | A parallel wave of steps finished successfully |
+| PR ready | Implementation done; PR link included |
+
+If GitHub integration is not configured (`IGitHubService.IsConfigured == false`), every method logs a warning and returns without throwing. This ensures that missing GitHub credentials never fail a story.
+
+---
+
+## Interface
+
+```csharp
+public interface IStoryProgressCommentService
+{
+    Task PostAnalysisCompleteCommentAsync(
+        string owner, string repo, int issueNumber, CancellationToken ct);
+
+    Task PostPlanningCompleteCommentAsync(
+        string owner, string repo, int issueNumber, int stepCount, CancellationToken ct);
+
+    Task PostWaveCompleteCommentAsync(
+        string owner, string repo, int issueNumber, int waveNumber, int totalWaves, CancellationToken ct);
+
+    Task PostPRReadyCommentAsync(
+        string owner, string repo, int issueNumber, string prLink, CancellationToken ct);
+}
+```
+
+---
+
+## Methods
+
+### `PostAnalysisCompleteCommentAsync`
+
+Posts a comment indicating that Aura has finished analysing the issue and is about to begin planning.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `owner` | `string` | GitHub repository owner (user or organisation) |
+| `repo` | `string` | GitHub repository name |
+| `issueNumber` | `int` | Issue number to comment on |
+| `ct` | `CancellationToken` | Cancellation token |
+
+**Comment posted:**
+```
+🔍 **Analysis complete.** Aura has finished analysing the issue and is now planning implementation steps.
+```
+
+---
+
+### `PostPlanningCompleteCommentAsync`
+
+Posts a comment indicating that Aura has produced an execution plan and is starting to run it.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `owner` | `string` | GitHub repository owner |
+| `repo` | `string` | GitHub repository name |
+| `issueNumber` | `int` | Issue number to comment on |
+| `stepCount` | `int` | Total number of steps in the plan |
+| `ct` | `CancellationToken` | Cancellation token |
+
+**Comment posted (example for 4 steps):**
+```
+📋 **Planning complete.** Aura has created a plan with **4 steps** and is now executing it.
+```
+
+---
+
+### `PostWaveCompleteCommentAsync`
+
+Posts a comment when a parallel wave of steps completes successfully. Only posted when the wave has zero failures.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `owner` | `string` | GitHub repository owner |
+| `repo` | `string` | GitHub repository name |
+| `issueNumber` | `int` | Issue number to comment on |
+| `waveNumber` | `int` | 1-based index of the completed wave |
+| `totalWaves` | `int` | Total number of waves in the plan |
+| `ct` | `CancellationToken` | Cancellation token |
+
+**Comment posted (example for wave 2 of 4):**
+```
+⚡ **Wave 2/4 complete.** Aura has finished executing wave 2 of 4.
+```
+
+---
+
+### `PostPRReadyCommentAsync`
+
+Posts a comment when Aura has successfully created a pull request, including a link to it.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `owner` | `string` | GitHub repository owner |
+| `repo` | `string` | GitHub repository name |
+| `issueNumber` | `int` | Issue number to comment on |
+| `prLink` | `string` | Full URL of the created pull request |
+| `ct` | `CancellationToken` | Cancellation token |
+
+**Comment posted:**
+```
+✅ **Pull request ready for review.** Aura has finished implementing this story.
+
+👉 [View Pull Request](https://github.com/owner/repo/pull/42)
+```
+
+---
+
+## Integration with StoryService
+
+`StoryService` receives `IStoryProgressCommentService` via constructor injection and calls it at the points shown below.
+
+### Wave complete (in `ExecuteAsync`)
+
+```csharp
+// After all steps in a wave finish with no failures:
+if (failedCount == 0
+    && story.IssueOwner is not null
+    && story.IssueRepo is not null
+    && story.IssueNumber is not null)
+{
+    await _progressCommentService.PostWaveCompleteCommentAsync(
+        story.IssueOwner, story.IssueRepo, story.IssueNumber.Value,
+        currentWave, waveCount, ct);
+}
+```
+
+### PR ready (in `CompleteAsync`)
+
+```csharp
+if (prResult.Success && prResult.Value is not null)
+{
+    workflow.PullRequestUrl = prResult.Value.Url;
+
+    if (workflow.IssueOwner is not null
+        && workflow.IssueRepo is not null
+        && workflow.IssueNumber is not null)
+    {
+        await _progressCommentService.PostPRReadyCommentAsync(
+            workflow.IssueOwner, workflow.IssueRepo, workflow.IssueNumber.Value,
+            prResult.Value.Url, ct);
+    }
+}
+```
+
+The guard checks (`IssueOwner is not null`, etc.) ensure comments are only attempted for stories that were created from a GitHub issue URL.
+
+---
+
+## Error Handling
+
+`StoryProgressCommentService` calls `EnsureConfigured()` at the top of every method:
+
+```csharp
+private bool EnsureConfigured()
+{
+    if (_gitHub.IsConfigured)
+    {
+        return true;
+    }
+
+    _logger.LogWarning("GitHub integration is not configured; skipping progress comment.");
+    return false;
+}
+```
+
+If `IGitHubService.IsConfigured` is `false` (e.g. no PAT configured), the method returns immediately and story execution continues normally. No exception is thrown.
+
+---
+
+## Registration
+
+The service is registered by `DeveloperModule` as a scoped dependency:
+
+```csharp
+services.AddScoped<IStoryProgressCommentService, StoryProgressCommentService>();
+```
+
+---
+
+## See Also
+
+- [`IGitHubService`](../../src/Aura.Module.Developer/GitHub/GitHubService.cs) – underlying GitHub API client used to post comments via `PostCommentAsync`
+- [`StoryService`](../../src/Aura.Module.Developer/Services/StoryService.cs) – orchestrates story execution and calls this service at lifecycle points
+- [`IStoryProgressCommentService`](../../src/Aura.Module.Developer/Services/IStoryProgressCommentService.cs) – interface definition

--- a/src/Aura.Module.Developer/DeveloperModule.cs
+++ b/src/Aura.Module.Developer/DeveloperModule.cs
@@ -56,6 +56,7 @@ public sealed class DeveloperModule : IAuraModule
         // Register Developer Module services
         services.AddScoped<IStoryService, StoryService>();
         services.AddScoped<IStoryExporter, StoryExporter>();
+        services.AddScoped<IStoryProgressCommentService, StoryProgressCommentService>();
         services.AddSingleton<ITreeBuilderService, TreeBuilderService>();
 
         // Register GitHub service with typed HttpClient

--- a/src/Aura.Module.Developer/Services/IStoryProgressCommentService.cs
+++ b/src/Aura.Module.Developer/Services/IStoryProgressCommentService.cs
@@ -1,0 +1,27 @@
+namespace Aura.Module.Developer.Services;
+
+/// <summary>
+/// Service for posting progress comments to GitHub issues during story execution
+/// </summary>
+public interface IStoryProgressCommentService
+{
+    /// <summary>
+    /// Posts a comment to a GitHub issue indicating that story analysis has completed
+    /// </summary>
+    Task PostAnalysisCompleteCommentAsync(string owner, string repo, int issueNumber, CancellationToken ct);
+
+    /// <summary>
+    /// Posts a comment to a GitHub issue indicating that story planning has completed with a summary of steps
+    /// </summary>
+    Task PostPlanningCompleteCommentAsync(string owner, string repo, int issueNumber, int stepCount, CancellationToken ct);
+
+    /// <summary>
+    /// Posts a comment to a GitHub issue indicating that a wave of steps has completed
+    /// </summary>
+    Task PostWaveCompleteCommentAsync(string owner, string repo, int issueNumber, int waveNumber, int totalWaves, CancellationToken ct);
+
+    /// <summary>
+    /// Posts a comment to a GitHub issue indicating that the story is ready for PR with a link to the pull request
+    /// </summary>
+    Task PostPRReadyCommentAsync(string owner, string repo, int issueNumber, string prLink, CancellationToken ct);
+}

--- a/src/Aura.Module.Developer/Services/StoryProgressCommentService.cs
+++ b/src/Aura.Module.Developer/Services/StoryProgressCommentService.cs
@@ -1,0 +1,85 @@
+// <copyright file="StoryProgressCommentService.cs" company="Aura">
+// Copyright (c) Aura. All rights reserved.
+// </copyright>
+
+namespace Aura.Module.Developer.Services;
+
+using Aura.Module.Developer.GitHub;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Posts progress comments to linked GitHub issues during story execution.
+/// </summary>
+public sealed class StoryProgressCommentService : IStoryProgressCommentService
+{
+    private readonly IGitHubService _gitHub;
+    private readonly ILogger<StoryProgressCommentService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StoryProgressCommentService"/> class.
+    /// </summary>
+    public StoryProgressCommentService(IGitHubService gitHub, ILogger<StoryProgressCommentService> logger)
+    {
+        _gitHub = gitHub;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task PostAnalysisCompleteCommentAsync(string owner, string repo, int issueNumber, CancellationToken ct)
+    {
+        if (!EnsureConfigured())
+        {
+            return;
+        }
+
+        var body = "🔍 **Analysis complete.** Aura has finished analysing the issue and is now planning implementation steps.";
+        await _gitHub.PostCommentAsync(owner, repo, issueNumber, body, ct);
+    }
+
+    /// <inheritdoc/>
+    public async Task PostPlanningCompleteCommentAsync(string owner, string repo, int issueNumber, int stepCount, CancellationToken ct)
+    {
+        if (!EnsureConfigured())
+        {
+            return;
+        }
+
+        var body = $"📋 **Planning complete.** Aura has created a plan with **{stepCount} step{(stepCount == 1 ? string.Empty : "s")}** and is now executing it.";
+        await _gitHub.PostCommentAsync(owner, repo, issueNumber, body, ct);
+    }
+
+    /// <inheritdoc/>
+    public async Task PostWaveCompleteCommentAsync(string owner, string repo, int issueNumber, int waveNumber, int totalWaves, CancellationToken ct)
+    {
+        if (!EnsureConfigured())
+        {
+            return;
+        }
+
+        var body = $"⚡ **Wave {waveNumber}/{totalWaves} complete.** Aura has finished executing wave {waveNumber} of {totalWaves}.";
+        await _gitHub.PostCommentAsync(owner, repo, issueNumber, body, ct);
+    }
+
+    /// <inheritdoc/>
+    public async Task PostPRReadyCommentAsync(string owner, string repo, int issueNumber, string prLink, CancellationToken ct)
+    {
+        if (!EnsureConfigured())
+        {
+            return;
+        }
+
+        var body = $"✅ **Pull request ready for review.** Aura has finished implementing this story.\n\n👉 [View Pull Request]({prLink})";
+        await _gitHub.PostCommentAsync(owner, repo, issueNumber, body, ct);
+    }
+
+    private bool EnsureConfigured()
+    {
+        if (_gitHub.IsConfigured)
+        {
+            return true;
+        }
+
+        _logger.LogWarning("GitHub integration is not configured; skipping progress comment.");
+        return false;
+    }
+}

--- a/src/Aura.Module.Developer/Services/StoryService.Planning.cs
+++ b/src/Aura.Module.Developer/Services/StoryService.Planning.cs
@@ -91,6 +91,12 @@ public sealed partial class StoryService
             workflow.Status = StoryStatus.Analyzed;
             workflow.UpdatedAt = DateTimeOffset.UtcNow;
             await _db.SaveChangesAsync(ct);
+
+            if (workflow.IssueOwner is not null && workflow.IssueRepo is not null && workflow.IssueNumber is not null)
+            {
+                await _progressCommentService.PostAnalysisCompleteCommentAsync(workflow.IssueOwner, workflow.IssueRepo, workflow.IssueNumber.Value, ct);
+            }
+
             _logger.LogInformation("Analyzed workflow {WorkflowId}", workflowId);
             return workflow;
         }
@@ -194,6 +200,12 @@ public sealed partial class StoryService
             await _db.SaveChangesAsync(ct);
             // Reload with steps
             var reloaded = await GetByIdWithStepsAsync(workflowId, ct);
+
+            if (workflow.IssueOwner is not null && workflow.IssueRepo is not null && workflow.IssueNumber is not null)
+            {
+                await _progressCommentService.PostPlanningCompleteCommentAsync(workflow.IssueOwner, workflow.IssueRepo, workflow.IssueNumber.Value, steps.Count, ct);
+            }
+
             _logger.LogInformation("Planned workflow {WorkflowId} with {StepCount} steps", workflowId, steps.Count);
             return reloaded!;
         }

--- a/src/Aura.Module.Developer/Services/StoryService.cs
+++ b/src/Aura.Module.Developer/Services/StoryService.cs
@@ -17,6 +17,7 @@ using Aura.Foundation.Rag;
 using Aura.Foundation.Tools;
 using Aura.Module.Developer.Data;
 using Aura.Module.Developer.Data.Entities;
+using Aura.Module.Developer.GitHub;
 using Aura.Module.Developer.Services.Verification;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -34,6 +35,7 @@ public sealed partial class StoryService(
     IPromptRegistry promptRegistry,
     IGitWorktreeService worktreeService,
     IGitService gitService,
+    IGitHubService gitHubService,
     IRagService ragService,
     IBackgroundIndexer backgroundIndexer,
     ICodebaseContextService codebaseContextService,
@@ -43,6 +45,7 @@ public sealed partial class StoryService(
     IStoryVerificationService verificationService,
     IStepExecutorRegistry stepExecutorRegistry,
     IQualityGateService qualityGateService,
+    IStoryProgressCommentService progressCommentService,
     IOptions<DeveloperModuleOptions> options,
     ILogger<StoryService> logger) : IStoryService
 {
@@ -51,6 +54,7 @@ public sealed partial class StoryService(
     private readonly IPromptRegistry _promptRegistry = promptRegistry;
     private readonly IGitWorktreeService _worktreeService = worktreeService;
     private readonly IGitService _gitService = gitService;
+    private readonly IGitHubService _gitHubService = gitHubService;
     private readonly IRagService _ragService = ragService;
     private readonly IBackgroundIndexer _backgroundIndexer = backgroundIndexer;
     private readonly ICodebaseContextService _codebaseContextService = codebaseContextService;
@@ -60,6 +64,7 @@ public sealed partial class StoryService(
     private readonly IStoryVerificationService _verificationService = verificationService;
     private readonly IStepExecutorRegistry _stepExecutorRegistry = stepExecutorRegistry;
     private readonly IQualityGateService _qualityGateService = qualityGateService;
+    private readonly IStoryProgressCommentService _progressCommentService = progressCommentService;
     private readonly DeveloperModuleOptions _options = options.Value;
     private readonly ILogger<StoryService> _logger = logger;
 
@@ -567,6 +572,11 @@ public sealed partial class StoryService(
 
             yield return StoryProgressEvent.WaveCompleted(storyId, currentWave, completedCount, failedCount);
 
+            if (failedCount == 0 && story.IssueOwner is not null && story.IssueRepo is not null && story.IssueNumber is not null)
+            {
+                await _progressCommentService.PostWaveCompleteCommentAsync(story.IssueOwner, story.IssueRepo, story.IssueNumber.Value, currentWave, waveCount, ct);
+            }
+
             if (failedCount > 0)
             {
                 story.Status = StoryStatus.Failed;
@@ -861,6 +871,11 @@ public sealed partial class StoryService(
                 {
                     workflow.PullRequestUrl = prResult.Value.Url;
                     _logger.LogInformation("Created PR: {Url}", prResult.Value.Url);
+
+                    if (workflow.IssueOwner is not null && workflow.IssueRepo is not null && workflow.IssueNumber is not null)
+                    {
+                        await _progressCommentService.PostPRReadyCommentAsync(workflow.IssueOwner, workflow.IssueRepo, workflow.IssueNumber.Value, prResult.Value.Url, ct);
+                    }
                 }
                 else
                 {

--- a/tests/Aura.Module.Developer.Tests/Services/StoryProgressCommentServiceTests.cs
+++ b/tests/Aura.Module.Developer.Tests/Services/StoryProgressCommentServiceTests.cs
@@ -1,0 +1,152 @@
+// <copyright file="StoryProgressCommentServiceTests.cs" company="Aura">
+// Copyright (c) Aura. All rights reserved.
+// </copyright>
+
+namespace Aura.Module.Developer.Tests.Services;
+
+using Aura.Module.Developer.GitHub;
+using Aura.Module.Developer.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+public class StoryProgressCommentServiceTests
+{
+    private readonly IGitHubService _gitHub = Substitute.For<IGitHubService>();
+    private readonly StoryProgressCommentService _sut;
+
+    public StoryProgressCommentServiceTests()
+    {
+        _gitHub.IsConfigured.Returns(true);
+        _sut = new StoryProgressCommentService(_gitHub, NullLogger<StoryProgressCommentService>.Instance);
+    }
+
+    [Fact]
+    public async Task PostAnalysisCompleteCommentAsync_WhenConfigured_PostsComment()
+    {
+        // Act
+        await _sut.PostAnalysisCompleteCommentAsync("owner", "repo", 42, CancellationToken.None);
+
+        // Assert
+        await _gitHub.Received(1).PostCommentAsync(
+            "owner", "repo", 42,
+            Arg.Is<string>(s => s.Contains("Analysis complete")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostAnalysisCompleteCommentAsync_WhenNotConfigured_SkipsComment()
+    {
+        // Arrange
+        _gitHub.IsConfigured.Returns(false);
+
+        // Act
+        await _sut.PostAnalysisCompleteCommentAsync("owner", "repo", 42, CancellationToken.None);
+
+        // Assert
+        await _gitHub.DidNotReceive().PostCommentAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostPlanningCompleteCommentAsync_WhenConfigured_PostsCommentWithStepCount()
+    {
+        // Act
+        await _sut.PostPlanningCompleteCommentAsync("owner", "repo", 42, 5, CancellationToken.None);
+
+        // Assert
+        await _gitHub.Received(1).PostCommentAsync(
+            "owner", "repo", 42,
+            Arg.Is<string>(s => s.Contains("Planning complete") && s.Contains("5 steps")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostPlanningCompleteCommentAsync_WithSingleStep_UsesSingularForm()
+    {
+        // Act
+        await _sut.PostPlanningCompleteCommentAsync("owner", "repo", 42, 1, CancellationToken.None);
+
+        // Assert
+        await _gitHub.Received(1).PostCommentAsync(
+            "owner", "repo", 42,
+            Arg.Is<string>(s => s.Contains("1 step") && !s.Contains("1 steps")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostPlanningCompleteCommentAsync_WhenNotConfigured_SkipsComment()
+    {
+        // Arrange
+        _gitHub.IsConfigured.Returns(false);
+
+        // Act
+        await _sut.PostPlanningCompleteCommentAsync("owner", "repo", 42, 5, CancellationToken.None);
+
+        // Assert
+        await _gitHub.DidNotReceive().PostCommentAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostWaveCompleteCommentAsync_WhenConfigured_PostsCommentWithWaveProgress()
+    {
+        // Act
+        await _sut.PostWaveCompleteCommentAsync("owner", "repo", 42, 2, 4, CancellationToken.None);
+
+        // Assert
+        await _gitHub.Received(1).PostCommentAsync(
+            "owner", "repo", 42,
+            Arg.Is<string>(s => s.Contains("Wave 2/4")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostWaveCompleteCommentAsync_WhenNotConfigured_SkipsComment()
+    {
+        // Arrange
+        _gitHub.IsConfigured.Returns(false);
+
+        // Act
+        await _sut.PostWaveCompleteCommentAsync("owner", "repo", 42, 2, 4, CancellationToken.None);
+
+        // Assert
+        await _gitHub.DidNotReceive().PostCommentAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostPRReadyCommentAsync_WhenConfigured_PostsCommentWithPrLink()
+    {
+        // Arrange
+        var prLink = "https://github.com/owner/repo/pull/99";
+
+        // Act
+        await _sut.PostPRReadyCommentAsync("owner", "repo", 42, prLink, CancellationToken.None);
+
+        // Assert
+        await _gitHub.Received(1).PostCommentAsync(
+            "owner", "repo", 42,
+            Arg.Is<string>(s => s.Contains("Pull request ready") && s.Contains(prLink)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostPRReadyCommentAsync_WhenNotConfigured_SkipsComment()
+    {
+        // Arrange
+        _gitHub.IsConfigured.Returns(false);
+
+        // Act
+        await _sut.PostPRReadyCommentAsync("owner", "repo", 42, "https://github.com/owner/repo/pull/99", CancellationToken.None);
+
+        // Assert
+        await _gitHub.DidNotReceive().PostCommentAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Aura.Module.Developer.Tests/Services/StoryServiceTests.cs
+++ b/tests/Aura.Module.Developer.Tests/Services/StoryServiceTests.cs
@@ -14,6 +14,7 @@ using Aura.Module.Developer.Data;
 using Aura.Module.Developer.Data.Entities;
 using Aura.Module.Developer.GitHub;
 using Aura.Module.Developer.Services;
+using Aura.Module.Developer.Services.Verification;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -21,7 +22,6 @@ using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
 using Aura.Module.Developer;
-using Aura.Module.Developer.Services.Verification;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading;
@@ -46,6 +46,7 @@ public class StoryServiceTests : IDisposable
     private readonly IStoryVerificationService _verificationService;
     private readonly IStepExecutorRegistry _stepExecutorRegistry;
     private readonly IQualityGateService _qualityGateService;
+    private readonly IStoryProgressCommentService _progressCommentService;
     private readonly IOptions<DeveloperModuleOptions> _options;
     private readonly StoryService _sut;
 
@@ -75,6 +76,7 @@ public class StoryServiceTests : IDisposable
         _verificationService = Substitute.For<IStoryVerificationService>();
         _stepExecutorRegistry = Substitute.For<IStepExecutorRegistry>();
         _qualityGateService = Substitute.For<IQualityGateService>();
+        _progressCommentService = Substitute.For<IStoryProgressCommentService>();
         _options = Options.Create(new DeveloperModuleOptions { BranchPrefix = "workflow/" });
 
         _sut = new StoryService(
@@ -93,6 +95,7 @@ public class StoryServiceTests : IDisposable
             _verificationService,
             _stepExecutorRegistry,
             _qualityGateService,
+            _progressCommentService,
             _options,
             NullLogger<StoryService>.Instance);
     }
@@ -544,6 +547,177 @@ public class StoryServiceTests : IDisposable
 
         // Assert
         result.Description.Should().Be("New description");
+    }
+
+    #endregion
+
+    #region IStoryProgressCommentService Integration Tests
+
+    [Fact]
+    public async Task CompleteAsync_WhenStoryHasLinkedIssueAndPRCreated_PostsPRReadyComment()
+    {
+        // Arrange
+        var story = await _sut.CreateAsync(
+            "PR Ready Test",
+            issueUrl: "https://github.com/owner/repo/issues/42");
+
+        // Set worktree path so git operations are triggered
+        story.WorktreePath = "/worktree/path";
+        story.RepositoryPath = "/repo/path";
+        await _sut.UpdateAsync(story);
+
+        // Add a step and mark it completed
+        var step = await _sut.AddStepAsync(story.Id, "Step 1", "code-review");
+        step.Status = StepStatus.Completed;
+        await _sut.UpdateStepAsync(step);
+
+        // Mock git service for the complete flow
+        _verificationService.VerifyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new Aura.Module.Developer.Services.Verification.VerificationResult
+            {
+                Success = true,
+                Projects = Array.Empty<Aura.Module.Developer.Services.Verification.DetectedProject>(),
+                StepResults = Array.Empty<Aura.Module.Developer.Services.Verification.VerificationStepResult>(),
+            });
+        _gitService.HasUncommittedChangesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<bool>.Ok(false));
+        _gitService.GetDefaultBranchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<string>.Ok("main"));
+        _gitService.SquashCommitsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<string>.Ok("abc123"));
+        _gitService.PushAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<Unit>.Ok(Unit.Value));
+        _gitService.CreatePullRequestAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<IReadOnlyList<string>?>(),
+                Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<PullRequestInfo>.Ok(new PullRequestInfo
+            {
+                Number = 99,
+                Url = "https://github.com/owner/repo/pull/99",
+                State = "open",
+                IsDraft = true,
+            }));
+
+        // Act
+        await _sut.CompleteAsync(story.Id);
+
+        // Assert
+        await _progressCommentService.Received(1).PostPRReadyCommentAsync(
+            "owner",
+            "repo",
+            42,
+            "https://github.com/owner/repo/pull/99",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CompleteAsync_WhenStoryHasNoLinkedIssue_DoesNotPostPRReadyComment()
+    {
+        // Arrange - story with no issue URL
+        var story = await _sut.CreateAsync("No Issue Test");
+
+        story.WorktreePath = "/worktree/path";
+        story.RepositoryPath = "/repo/path";
+        await _sut.UpdateAsync(story);
+
+        var step = await _sut.AddStepAsync(story.Id, "Step 1", "code-review");
+        step.Status = StepStatus.Completed;
+        await _sut.UpdateStepAsync(step);
+
+        _verificationService.VerifyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new Aura.Module.Developer.Services.Verification.VerificationResult
+            {
+                Success = true,
+                Projects = Array.Empty<Aura.Module.Developer.Services.Verification.DetectedProject>(),
+                StepResults = Array.Empty<Aura.Module.Developer.Services.Verification.VerificationStepResult>(),
+            });
+        _gitService.HasUncommittedChangesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<bool>.Ok(false));
+        _gitService.GetDefaultBranchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<string>.Ok("main"));
+        _gitService.SquashCommitsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<string>.Ok("abc123"));
+        _gitService.PushAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<Unit>.Ok(Unit.Value));
+        _gitService.CreatePullRequestAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<IReadOnlyList<string>?>(),
+                Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<PullRequestInfo>.Ok(new PullRequestInfo
+            {
+                Number = 99,
+                Url = "https://github.com/owner/repo/pull/99",
+                State = "open",
+                IsDraft = true,
+            }));
+
+        // Act
+        await _sut.CompleteAsync(story.Id);
+
+        // Assert - no PR comment because story has no issue linked
+        await _progressCommentService.DidNotReceive().PostPRReadyCommentAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CompleteAsync_WhenGitHubNotConfigured_ProgressCommentServiceStillCalled()
+    {
+        // The StoryService delegates config checking to IStoryProgressCommentService.
+        // It calls PostPRReadyCommentAsync regardless of IsConfigured; the service handles graceful fallback.
+        // Arrange
+        _gitHubService.IsConfigured.Returns(false);
+
+        var story = await _sut.CreateAsync(
+            "Unconfigured GitHub Test",
+            issueUrl: "https://github.com/owner/repo/issues/10");
+
+        story.WorktreePath = "/worktree/path";
+        story.RepositoryPath = "/repo/path";
+        await _sut.UpdateAsync(story);
+
+        var step = await _sut.AddStepAsync(story.Id, "Step 1", "code-review");
+        step.Status = StepStatus.Completed;
+        await _sut.UpdateStepAsync(step);
+
+        _verificationService.VerifyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new Aura.Module.Developer.Services.Verification.VerificationResult
+            {
+                Success = true,
+                Projects = Array.Empty<Aura.Module.Developer.Services.Verification.DetectedProject>(),
+                StepResults = Array.Empty<Aura.Module.Developer.Services.Verification.VerificationStepResult>(),
+            });
+        _gitService.HasUncommittedChangesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<bool>.Ok(false));
+        _gitService.GetDefaultBranchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<string>.Ok("main"));
+        _gitService.SquashCommitsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<string>.Ok("abc123"));
+        _gitService.PushAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<Unit>.Ok(Unit.Value));
+        _gitService.CreatePullRequestAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<IReadOnlyList<string>?>(),
+                Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(GitResult<PullRequestInfo>.Ok(new PullRequestInfo
+            {
+                Number = 10,
+                Url = "https://github.com/owner/repo/pull/10",
+                State = "open",
+                IsDraft = true,
+            }));
+
+        // Act - should not throw even when GitHub is not configured
+        await _sut.CompleteAsync(story.Id);
+
+        // Assert - StoryService still calls the progress comment service; the service itself handles the missing config
+        await _progressCommentService.Received(1).PostPRReadyCommentAsync(
+            "owner",
+            "repo",
+            10,
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
     }
 
     #endregion

--- a/tests/Aura.Module.Developer.Tests/Services/StoryServiceTests.cs
+++ b/tests/Aura.Module.Developer.Tests/Services/StoryServiceTests.cs
@@ -12,6 +12,7 @@ using Aura.Foundation.Rag;
 using Aura.Foundation.Tools;
 using Aura.Module.Developer.Data;
 using Aura.Module.Developer.Data.Entities;
+using Aura.Module.Developer.GitHub;
 using Aura.Module.Developer.Services;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -35,6 +36,7 @@ public class StoryServiceTests : IDisposable
     private readonly IPromptRegistry _promptRegistry;
     private readonly IGitWorktreeService _worktreeService;
     private readonly IGitService _gitService;
+    private readonly IGitHubService _gitHubService;
     private readonly IRagService _ragService;
     private readonly IBackgroundIndexer _backgroundIndexer;
     private readonly ICodebaseContextService _codebaseContextService;
@@ -63,6 +65,7 @@ public class StoryServiceTests : IDisposable
         _worktreeService.CreateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(GitResult<WorktreeInfo>.Fail("Test mode - no worktree creation")));
         _gitService = Substitute.For<IGitService>();
+        _gitHubService = Substitute.For<IGitHubService>();
         _ragService = Substitute.For<IRagService>();
         _backgroundIndexer = Substitute.For<IBackgroundIndexer>();
         _codebaseContextService = Substitute.For<ICodebaseContextService>();
@@ -80,6 +83,7 @@ public class StoryServiceTests : IDisposable
             _promptRegistry,
             _worktreeService,
             _gitService,
+            _gitHubService,
             _ragService,
             _backgroundIndexer,
             _codebaseContextService,


### PR DESCRIPTION
## Add progress comments to linked GitHub issues during story execution

When a story is linked to a GitHub issue, post progress comments at key milestones:
- When story analysis completes
- When planning completes (with step summary)
- When each wave of steps completes
- When story is ready for PR

Use existing GitHubService.PostCommentAsync(). Add calls in StoryService at appropriate lifecycle points.

Gracefully handle missing GitHub config (log warning, don't fail story execution).

Acceptance Criteria:
- Comment posted when story enters Analyzing state
- Comment posted when story enters Planned state (include step count)
- Comment posted when each wave completes (progress: Wave 2/4 complete)
- Final comment when PR is created (include PR link)
- Comments formatted with robot badge and Aura branding
- Gracefully handle missing GitHub config

### story Steps

- ✅ Create IStoryProgressCommentService interface
- ✅ Implement StoryProgressCommentService
- ✅ Integrate StoryProgressCommentService into StoryService
- ✅ Add dependency injection for StoryProgressCommentService
- ⬜ Create unit tests for StoryService integration
- ⬜ Document StoryProgressCommentService

---
*Created by [Aura](https://github.com/johnazariah/aura)*
