### PR TITLE
feat(developer): use repository PR template when creating pull requests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -173,6 +173,24 @@ The pre-commit hook will reject files with CRLF line endings.
 | New feature | `.project/features/upcoming/` | Create spec first |
 | Complete feature | `.project/features/completed/` | **Follow ceremony** (see below) |
 
+## Interactive Story Workflow
+
+You can work on an Aura story interactively from any Copilot CLI session. Use the `/work-on-story` prompt to bootstrap, or follow this flow manually:
+
+1. **Find your story**: `aura_workflow(operation: "list")` or `aura_workflow(operation: "get", storyId: "...")`
+2. **Get next step**: `aura_workflow(operation: "next_step", storyId: "...")` — returns the next actionable step with full context
+3. **Start the step**: `aura_workflow(operation: "start_step", storyId: "...", stepId: "...")` — marks it Running
+4. **Do the work**: Edit files in the worktree using **absolute paths** from the step context
+5. **Complete the step**: `aura_workflow(operation: "update_step", storyId: "...", stepId: "...", status: "completed", output: "...")`
+6. **Repeat** until all steps done, then `aura_workflow(operation: "complete", storyId: "...")`
+
+**Critical conventions when working on a story:**
+- Your cwd is the main workspace, but **file edits must target the worktree** (absolute paths)
+- Use `worktreeSolutionPath` from step context for `aura_validate` calls
+- Use `repositoryPath` for `aura_search` — RAG indexes the main repo, not the worktree
+- Run git commands with `cd <worktreePath> && git ...`
+- Load the full pattern: `aura_pattern(operation: "get", name: "interactive-story")`
+
 ## Blast Radius Protocol (Renames, Extract, Large Changes)
 
 `aura_refactor` defaults to **analyze mode** (`analyze: true`). Before executing any refactoring:

--- a/src/Aura.Api/Endpoints/DeveloperEndpoints.cs
+++ b/src/Aura.Api/Endpoints/DeveloperEndpoints.cs
@@ -891,6 +891,18 @@ public static class DeveloperEndpoints
     private static string BuildPrBody(Story story)
     {
         var sb = new StringBuilder();
+
+        // Attribution banner
+        sb.AppendLine("> 🤖 **This pull request was created by [Aura](https://github.com/johnazariah/aura)** — an AI-powered coding agent.");
+        sb.AppendLine();
+
+        // Link to source issue (enables auto-close on merge)
+        if (!string.IsNullOrEmpty(story.IssueUrl))
+        {
+            sb.AppendLine($"Closes {story.IssueUrl}");
+            sb.AppendLine();
+        }
+
         sb.AppendLine($"## {story.Title}");
         sb.AppendLine();
         if (!string.IsNullOrEmpty(story.Description))
@@ -898,7 +910,7 @@ public static class DeveloperEndpoints
             sb.AppendLine(story.Description);
             sb.AppendLine();
         }
-        sb.AppendLine("### story Steps");
+        sb.AppendLine("### Steps");
         sb.AppendLine();
         foreach (var step in story.Steps.OrderBy(s => s.Order))
         {
@@ -911,9 +923,34 @@ public static class DeveloperEndpoints
             };
             sb.AppendLine($"- {status} {step.Name}");
         }
+
+        // Append repository PR template if found
+        var repoPath = story.WorktreePath ?? story.RepositoryPath;
+        if (!string.IsNullOrEmpty(repoPath))
+        {
+            var templatePaths = new[]
+            {
+                Path.Combine(repoPath, ".github", "PULL_REQUEST_TEMPLATE.md"),
+                Path.Combine(repoPath, ".github", "PULL_REQUEST_TEMPLATE", "default.md"),
+                Path.Combine(repoPath, "PULL_REQUEST_TEMPLATE.md"),
+            };
+
+            foreach (var path in templatePaths)
+            {
+                if (File.Exists(path))
+                {
+                    sb.AppendLine();
+                    sb.AppendLine("---");
+                    sb.AppendLine();
+                    sb.AppendLine(File.ReadAllText(path));
+                    break;
+                }
+            }
+        }
+
         sb.AppendLine();
         sb.AppendLine("---");
-        sb.AppendLine("*Created by [Aura](https://github.com/johnazariah/aura)*");
+        sb.AppendLine($"*Created by [Aura](https://github.com/johnazariah/aura) · workflow `{story.Id}`*");
         return sb.ToString();
     }
 

--- a/src/Aura.Module.Developer/Services/StoryService.cs
+++ b/src/Aura.Module.Developer/Services/StoryService.cs
@@ -922,10 +922,49 @@ public sealed partial class StoryService(
                 : "⚠️ Verification had issues — please review");
         }
 
+        // Append repository PR template if found
+        var repoPath = workflow.WorktreePath ?? workflow.RepositoryPath;
+        var template = FindPullRequestTemplate(repoPath);
+        if (template is not null)
+        {
+            sb.AppendLine();
+            sb.AppendLine("---");
+            sb.AppendLine();
+            sb.AppendLine(template);
+        }
+
         sb.AppendLine();
         sb.AppendLine("---");
         sb.AppendLine($"*Implemented autonomously by Aura · workflow `{workflow.Id}`*");
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Searches for a pull request template in the repository.
+    /// </summary>
+    private static string? FindPullRequestTemplate(string? repoPath)
+    {
+        if (string.IsNullOrEmpty(repoPath))
+        {
+            return null;
+        }
+
+        var templatePaths = new[]
+        {
+            Path.Combine(repoPath, ".github", "PULL_REQUEST_TEMPLATE.md"),
+            Path.Combine(repoPath, ".github", "PULL_REQUEST_TEMPLATE", "default.md"),
+            Path.Combine(repoPath, "PULL_REQUEST_TEMPLATE.md"),
+        };
+
+        foreach (var path in templatePaths)
+        {
+            if (File.Exists(path))
+            {
+                return File.ReadAllText(path);
+            }
+        }
+
+        return null;
     }
 
     private static string BuildSquashCommitMessage(Story workflow)


### PR DESCRIPTION
## Summary

When creating a PR, Aura now checks for a PR template in the repository and appends it to the generated PR body.

### Template Locations (checked in order)
1. \.github/PULL_REQUEST_TEMPLATE.md\
2. \.github/PULL_REQUEST_TEMPLATE/default.md\
3. \PULL_REQUEST_TEMPLATE.md\ (repo root)

### Also Fixes
- \/finalize\ endpoint now has attribution banner, \Closes\ footer, and workflow ID

---
*Created by Aura*